### PR TITLE
Chapter list caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Author**: Megan Flood
 
-**Version**: 0.2.1
+**Version**: 0.3.0
 
 ## Overview
 Download the chapters of your favorite manga from various sources online to your computer for offline reading.
@@ -41,7 +41,7 @@ In order to use the scraper directly, you must create a series and a source to p
 >>> source = MangaSource('Top Manga', 'http://www.manga.com', '-')
 ```
 
-Then to get the chapters available on the source for the series.
+Then, you can get the chapters available on the source for the series.
 ```python
 >>> from manga_saver.scraper import Scraper
 
@@ -55,9 +55,9 @@ Then to get the chapters available on the source for the series.
 }
 ```
 
-To get a generator of the binary data for the page images of a chapter.
+Or you can get a generator of the binary data of the page images for a chapter.
 ```python
->>> pages = Scraper.chapter_pages('http://www.manga.com/best-series-ever/55', source)
+>>> pages = Scraper.chapter_pages('55', series, source)
 >>> next(pages)
 
 (b'\x0b\xb1\x8eV\xf7b(\xe4\xee\x0e...', 'png')
@@ -77,9 +77,12 @@ You can test this application by running `pytest` in the same directory as the `
 ## Architecture
 Written in [Python 3.6](https://www.python.org/), with [pytest](https://docs.pytest.org/en/latest/) for testing.
 
+Uses [BeautifulSoup4](https://www.crummy.com/software/BeautifulSoup/) for parsing HTML and [Requests](http://docs.python-requests.org/en/master/) to retrieve HTML pages and images.
+
 ## Change Log
 | Date | &emsp;
 | :--- | ---
+|**5-27-2018 7:03pm** | Added chapter list caching to SeriesCache and refactored public Scraper methods.
 |**5-25-2018 12:26am** | Completed first iteration of Scraper class and SeriesCache model.
 |**4-21-2018 11:17pm** | Completed first iteration of MangaSource model.
 |**4-21-2018 7:30pm** | Setup testing and automated testing.

--- a/README.md
+++ b/README.md
@@ -4,13 +4,78 @@
 
 **Author**: Megan Flood
 
-**Version**: 0.2.0
+**Version**: 0.2.1
 
 ## Overview
 Download the chapters of your favorite manga from various sources online to your computer for offline reading.
 
+## Getting Started
+Clone this repository to your local machine.
+```bash
+$ git clone https://github.com/musflood/manga-gui.git
+```
+
+Once downloaded, change directory into the `manga-gui` directory.
+```bash
+$ cd manga-gui
+```
+
+Begin a new virtual environment with Python 3 and activate it.
+```bash
+manga-gui $ python3.6 -m venv ENV
+manga-gui $ source ENV/bin/activate
+```
+
+Install the application with [`pip`](https://pip.pypa.io/en/stable/installing/).
+```bash
+(ENV) manga-gui $ pip install -e .
+```
+
+## Usage
+In order to use the scraper directly, you must create a series and a source to pull from.
+```python
+>>> from manga_saver.mangasource import MangaSource
+>>> from manga_saver.seriescache import SeriesCache
+
+>>> series = SeriesCache('The Best Series Ever')
+>>> source = MangaSource('Top Manga', 'http://www.manga.com', '-')
+```
+
+Then to get the chapters available on the source for the series.
+```python
+>>> from manga_saver.scraper import Scraper
+
+>>> Scraper.chapter_list(series, source)
+
+{
+    '55': 'http://www.manga.com/best-series-ever/55',
+    '54': 'http://www.manga.com/best-series-ever/54',
+    '53': 'http://www.manga.com/best-series-ever/53',
+    '52': 'http://www.manga.com/best-series-ever/52'
+}
+```
+
+To get a generator of the binary data for the page images of a chapter.
+```python
+>>> pages = Scraper.chapter_pages('http://www.manga.com/best-series-ever/55', source)
+>>> next(pages)
+
+(b'\x0b\xb1\x8eV\xf7b(\xe4\xee\x0e...', 'png')
+```
+
+## Testing
+Make sure you have the `testing` set of dependancies installed.
+```bash
+(ENV) manga-gui $ pip install -e .[testing]
+```
+
+You can test this application by running `pytest` in the same directory as the `setup.py` file.
+```bash
+(ENV) manga-gui $ pytest
+```
+
 ## Architecture
-Written in [Python](https://www.python.org/), with [pytest](https://docs.pytest.org/en/latest/) for testing.
+Written in [Python 3.6](https://www.python.org/), with [pytest](https://docs.pytest.org/en/latest/) for testing.
 
 ## Change Log
 | Date | &emsp;

--- a/manga_saver/mangasource.py
+++ b/manga_saver/mangasource.py
@@ -82,10 +82,10 @@ class MangaSource(object):
         # Details for parsing page and chapter HTML
         self.is_multipage = is_multipage
 
-        self.pg_img_attrs = pg_img_attrs
+        self.pg_img_attrs = pg_img_attrs if pg_img_attrs else {}
 
         self.index_tag = index_tag
-        self.index_attrs = index_attrs
+        self.index_attrs = index_attrs if index_attrs else {}
 
     def __repr__(self):
         """Display the name and url for the source."""

--- a/manga_saver/scraper.py
+++ b/manga_saver/scraper.py
@@ -46,6 +46,7 @@ class Scraper(object):
             source.index_tag, attrs=source.index_attrs)
 
         if not index_html:
+            series.set_chapter_list(source, None)
             raise ValueError('No chapter list found in source.')
 
         chapter_re = re.compile(r'(\D|\b)\d+(\D|\b)')
@@ -102,7 +103,7 @@ class Scraper(object):
         return chapter_number
 
     @classmethod
-    def chapter_pages(cls, chapter_url, source):
+    def chapter_pages(cls, chapter, series, source):
         """Generate the pages for a chapter of the series from a source.
 
         Args:
@@ -117,12 +118,25 @@ class Scraper(object):
             ValueError: For empty chapter.
 
         """
-        if type(chapter_url) is not str:
+        if type(chapter) is not str:
             raise TypeError('Chapter URL must be a string.')
+        if not isinstance(series, SeriesCache):
+            raise TypeError('Given series must be a SeriesCache.')
         if not isinstance(source, MangaSource):
             raise TypeError('Given source must be a MangaSource.')
-        if not chapter_url:
-            raise ValueError('Cannot use an empty string for chapter URL.')
+        if not chapter:
+            raise ValueError('Cannot use an empty string for chapter.')
+
+        chapter_urls = series.get_chapter_list(source)
+        if chapter_urls is None:
+            chapter_urls = cls.chapter_list(series, source)
+
+        try:
+            chapter_url = chapter_urls[chapter]
+        except KeyError:
+            raise KeyError(f'Chapter {chapter} not available from {source}.')
+
+        print(chapter_url)
 
         if source.is_multipage:
             pages = cls._generate_multipage_chapter(chapter_url, source)

--- a/manga_saver/scraper.py
+++ b/manga_saver/scraper.py
@@ -115,7 +115,8 @@ class Scraper(object):
 
         Raises:
             TypeError: For improperly typed arguments.
-            ValueError: For empty chapter.
+            ValueError: For en empty chapter number.
+            KeyError: For a chapter that is not available.
 
         """
         if type(chapter) is not str:
@@ -135,8 +136,6 @@ class Scraper(object):
             chapter_url = chapter_urls[chapter]
         except KeyError:
             raise KeyError(f'Chapter {chapter} not available from {source}.')
-
-        print(chapter_url)
 
         if source.is_multipage:
             pages = cls._generate_multipage_chapter(chapter_url, source)

--- a/manga_saver/scraper.py
+++ b/manga_saver/scraper.py
@@ -36,6 +36,10 @@ class Scraper(object):
         if index_url and type(index_url) is not str:
             raise TypeError('URL must be a string.')
 
+        chapters = series.get_chapter_list(source)
+        if chapters is not None:
+            return chapters
+
         index_html = series.get_index(source, index_url)
         index_html = BeautifulSoup(index_html, 'html.parser')
         index_html = index_html.find(
@@ -60,8 +64,14 @@ class Scraper(object):
         find_ch = cls._make_chapter_finder(series.title)
         root_url = source.index_url(series.title)
 
-        return {find_ch(tag.text): urllib.parse.urljoin(root_url, tag['href'])
-                for tag in chap_links}
+        chapters = {
+            find_ch(tag.text): urllib.parse.urljoin(root_url, tag['href'])
+            for tag in chap_links
+        }
+
+        series.set_chapter_list(source, chapters)
+
+        return chapters
 
     @classmethod
     def _make_chapter_finder(cls, series_title):

--- a/manga_saver/scraper.py
+++ b/manga_saver/scraper.py
@@ -38,8 +38,8 @@ class Scraper(object):
 
         index_html = series.get_index(source, index_url)
         index_html = BeautifulSoup(index_html, 'html.parser')
-        index_html = index_html.find(source.index_tag,
-                                     attrs=source.index_attrs)
+        index_html = index_html.find(
+            source.index_tag, attrs=source.index_attrs)
 
         if not index_html:
             raise ValueError('No chapter list found in source.')
@@ -58,8 +58,10 @@ class Scraper(object):
         chap_links = index_html.findAll(chapter_anchor_tag)
 
         find_ch = cls._make_chapter_finder(series.title)
+        root_url = source.index_url(series.title)
 
-        return {find_ch(tag.text): tag['href'] for tag in chap_links}
+        return {find_ch(tag.text): urllib.parse.urljoin(root_url, tag['href'])
+                for tag in chap_links}
 
     @classmethod
     def _make_chapter_finder(cls, series_title):

--- a/manga_saver/seriescache.py
+++ b/manga_saver/seriescache.py
@@ -1,5 +1,6 @@
 """Model for a single series of manga to allow caching of index pages."""
 from datetime import datetime
+import re
 
 from manga_saver.mangasource import MangaSource
 
@@ -14,22 +15,32 @@ class SeriesCache(object):
 
     """
 
-    def __init__(self, title):
-        """Set up a new empty cache."""
+    def __init__(self, title, update_interval=21600):
+        """Set up a new empty cache.
+
+        Update interval is used to determine when a cache is outdated.
+        Default is 21600 seconds, or 6 hours.
+        """
         if type(title) is not str:
             raise TypeError('title must be a string.')
         if not title:
             raise ValueError('title cannot be an empty string.')
+        if type(update_interval) is not int:
+            raise TypeError('Update interval must be an integer.')
+        if update_interval < 0:
+            raise ValueError('Update interval cannot be negative.')
 
         self.title = title
+        self._update_interval = update_interval
+
         self._index_pages = {}
+        self._chapter_lists = {}
         self._custom_urls = {}
         self._last_updated = {}
 
     def __repr__(self):
         """Display the name and cache size of the series."""
-        cache_size = len(self._index_pages)
-        return f'<SeriesCache: {self.title}, cache: {cache_size} sources>'
+        return f'<SeriesCache: {self.title}, cache: {len(self)} sources>'
 
     def __str__(self):
         """Display the name of the series."""
@@ -42,6 +53,16 @@ class SeriesCache(object):
     def __contains__(self, item):
         """Check if the item is in the cache."""
         return repr(item) in self._index_pages
+
+    def has_outdated_cache(self, source):
+        """Check if cache for a source is older than the update interval."""
+        if not isinstance(source, MangaSource):
+            raise TypeError('source must be a MangaSource.')
+
+        now = datetime.utcnow().timestamp()
+
+        last_update = self._last_updated[repr(source)] if source in self else 0
+        return now - last_update > self._update_interval
 
     def update_index(self, source, index_url=None):
         """Store the html for the index page at a source.
@@ -68,10 +89,9 @@ class SeriesCache(object):
         res = requests.get(index_url)
 
         self._index_pages[src_name] = res.text
-        now = datetime.utcnow().timestamp()
-        self._last_updated[src_name] = now
+        self._last_updated[src_name] = datetime.utcnow().timestamp()
 
-    def get_index(self, source, index_url=None, update_interval=21600):
+    def get_index(self, source, index_url=None):
         """Get the html for the index page at a source.
 
         Also updates the stored html for a source if the update
@@ -81,19 +101,49 @@ class SeriesCache(object):
             raise TypeError('source must be a MangaSource.')
         if index_url is not None and type(index_url) is not str:
             raise TypeError('URL must be a string.')
-        if type(update_interval) is not int:
-            raise TypeError('Update interval must be an integer.')
-        if update_interval < 0:
-            raise ValueError('Update interval cannot be negative.')
-
-        now = datetime.utcnow().timestamp()
-
-        last_update = self._last_updated[repr(source)] if source in self else 0
-        is_old_cache = now - last_update > update_interval
 
         is_new_url = index_url and self._custom_urls[repr(source)] != index_url
 
-        if is_new_url or is_old_cache:
+        if is_new_url or self.has_outdated_cache(source):
             self.update_index(source, index_url)
 
         return self._index_pages[repr(source)]
+
+    def set_chapter_list(self, source, chapter_list):
+        """Store the chapter list at a source.
+
+        chapter_list must be a dictionary with a string of the chapter number
+        as the key and the URL to the first or only page of the chapter
+        as the value.
+        """
+        if not isinstance(source, MangaSource):
+            raise TypeError('source must be a MangaSource.')
+        if source not in self:
+            raise ValueError(
+                'Cannot set chapter list for source without index.')
+
+        number_re = re.compile(r'\d+\.\d+|\d+')
+        if type(chapter_list) is not dict:
+            raise TypeError('chapter_list must be a dictionary.')
+        if not all(type(key) is str and number_re.fullmatch(key)
+                   for key in chapter_list):
+            raise ValueError('Improperly formatted chapter numbers.')
+        if not all(type(val) is str and val.startswith('http')
+                   for val in chapter_list.values()):
+            raise ValueError('Improperly formatted chapter URLs.')
+
+        self._chapter_lists[repr(source)] = chapter_list
+
+    def get_chapter_list(self, source):
+        """Get the chapter list at a source.
+
+        If the cache is out of date for the source, always returns None.
+        Default is 21600 seconds, or 6 hours.
+        """
+        if not isinstance(source, MangaSource):
+            raise TypeError('source must be a MangaSource.')
+
+        if self.has_outdated_cache(source):
+            return
+
+        return self._chapter_lists.get(repr(source), None)

--- a/manga_saver/seriescache.py
+++ b/manga_saver/seriescache.py
@@ -123,13 +123,13 @@ class SeriesCache(object):
                 'Cannot set chapter list for source without index.')
 
         number_re = re.compile(r'\d+\.\d+|\d+')
-        if type(chapter_list) is not dict:
+        if chapter_list is not None and type(chapter_list) is not dict:
             raise TypeError('chapter_list must be a dictionary.')
         if not all(type(key) is str and number_re.fullmatch(key)
-                   for key in chapter_list):
+                   for key in (chapter_list if chapter_list else [])):
             raise ValueError('Improperly formatted chapter numbers.')
         if not all(type(val) is str and val.startswith('http')
-                   for val in chapter_list.values()):
+                   for val in (chapter_list.values() if chapter_list else [])):
             raise ValueError('Improperly formatted chapter URLs.')
 
         self._chapter_lists[repr(source)] = chapter_list

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -116,7 +116,7 @@ def filled_cache(dummy_source):
             name: source2
             url: http://www.another.com/
             slug: -
-        MangaSource: -> No chapters, last updated 12 hours ago, custom url
+        MangaSource: -> No chapters, last updated 12 hours ago, custom url,
             name: old-source
             url: http://old.net/
             slug:
@@ -141,6 +141,14 @@ def filled_cache(dummy_source):
         repr(dummy_source): now,
         '<MangaSource: source2 @ http://www.another.com/>': now - 7200,
         '<MangaSource: old-source @ http://old.net/>': now - 43200
+    }
+    cache._chapter_lists = {
+        '<MangaSource: source2 @ http://www.another.com/>':
+            {
+                '5': 'http://another.net/test-series/5',
+                '4': 'http://another.net/test-series/4'
+            },
+        '<MangaSource: old-source @ http://old.net/>': {}
     }
 
     return cache

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -126,9 +126,10 @@ def filled_cache(dummy_source):
     cache = seriescache.SeriesCache('test series')
     cache._index_pages = {
         repr(dummy_source): '<a href="/test_series/1">Chapter link</a>',
-        '<MangaSource: source2 @ http://www.another.com/>': '''
+        '<MangaSource: source2 @ http://www.another.com/>': '''<table>
             <a href="/test-series/5">Chapter link</a>
-            <a href="/test-series/4">Chapter link</a>''',
+            <a href="/test-series/4">Chapter link</a>
+            </table>''',
         '<MangaSource: old-source @ http://old.net/>': '<p>No chapters</p>'
     }
     cache._custom_urls = {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,6 +23,8 @@ TEST_PAGE = '''
 <a href="/001/page/3"><img src="http://files.co/test.png" id="2"></a>
 <a href="/001/page/4"><img src="http://files.co/test.png" id="3"></a>
 <a href="/002/page/1"><img src="http://files.co/test.png" id="4"></a>
+
+<table><a href="/001/page/1">Chapter 1</a></table>
 </body>
 '''
 
@@ -111,12 +113,13 @@ def filled_cache(dummy_source):
     """Create an filled series cache.
 
     Has data for the following:
-        dummy_source -> Chp 1 only, last updated now
+        dummy_source -> Chp 1 only, last updated now, chapter list
         MangaSource: -> Chps 4 and 5, last updated 2 hours ago
             name: source2
             url: http://www.another.com/
             slug: -
         MangaSource: -> No chapters, last updated 12 hours ago, custom url,
+                        chapter list
             name: old-source
             url: http://old.net/
             slug:
@@ -125,7 +128,7 @@ def filled_cache(dummy_source):
 
     cache = seriescache.SeriesCache('test series')
     cache._index_pages = {
-        repr(dummy_source): '<a href="/test_series/1">Chapter link</a>',
+        repr(dummy_source): '<a href="/test_series/1/page/1">Chapter link</a>',
         '<MangaSource: source2 @ http://www.another.com/>': '''<table>
             <a href="/test-series/5">Chapter link</a>
             <a href="/test-series/4">Chapter link</a>
@@ -144,11 +147,9 @@ def filled_cache(dummy_source):
         '<MangaSource: old-source @ http://old.net/>': now - 43200
     }
     cache._chapter_lists = {
-        '<MangaSource: source2 @ http://www.another.com/>':
-            {
-                '5': 'http://another.net/test-series/5',
-                '4': 'http://another.net/test-series/4'
-            },
+        repr(dummy_source): {
+            '1': 'http://www.source.com/test_series/1/page/1'
+        },
         '<MangaSource: old-source @ http://old.net/>': {}
     }
 

--- a/tests/test_scraper.py
+++ b/tests/test_scraper.py
@@ -422,7 +422,7 @@ def test_chapter_list_finds_all_chapters(various_indexes):
 def test_chapter_list_gets_chapter_numbers_for_all_entries(various_indexes):
     """Test chapter_list gets the chapter number from the index entry."""
     chapters = scr.Scraper.chapter_list(*various_indexes)
-    assert all([chap.replace('.', '').isdecimal() for chap in chapters])
+    assert all([chap.replace('.', '', 1).isdecimal() for chap in chapters])
 
 
 def test_chapter_list_gets_chapter_number_without_html(various_indexes):

--- a/tests/test_scraper.py
+++ b/tests/test_scraper.py
@@ -434,7 +434,7 @@ def test_chapter_list_gets_chapter_number_without_html(various_indexes):
 def test_chapter_list_gets_url_for_each_chapter(various_indexes):
     """Test chapter_list gets the url for each chapter."""
     chapters = scr.Scraper.chapter_list(*various_indexes)
-    assert all([url.startswith('/') for url in chapters.values()])
+    assert all([url.startswith('http') for url in chapters.values()])
 
 
 @pytest.mark.parametrize('value', [500, [], 2.1, {}])

--- a/tests/test_scraper.py
+++ b/tests/test_scraper.py
@@ -107,8 +107,8 @@ def test_get_page_removes_image_link_from_html(dummy_source):
     assert html.find('a', href=lambda h: h in next_page) is None
 
 
-def test_get_page_has_empty_string_for_next_page_without_a_tag(dummy_source,
-                                                               monkeypatch):
+def test_get_page_has_empty_string_for_next_page_without_a_tag(
+        dummy_source, monkeypatch):
     """Test _get_page returns an empty string for next page URL on img tag."""
     import requests
     req = requests_patch(text='<img src="https://file.co/img.png">',
@@ -170,8 +170,8 @@ def test_generate_multipage_chapter_yields_image_and_extension(dummy_source):
     assert ext == 'png'
 
 
-def test_generate_multipage_chapter_yields_all_images_in_chapter(dummy_source,
-                                                                 monkeypatch):
+def test_generate_multipage_chapter_yields_all_images_in_chapter(
+        dummy_source, monkeypatch):
     """Test _generate_multipage_chapter yeilds image data and extention."""
     import requests
 
@@ -200,8 +200,8 @@ def test_generate_multipage_chapter_yields_all_images_in_chapter(dummy_source,
     assert imgs[0] != imgs[1] != imgs[2] != imgs[3]
 
 
-def test_generate_multipage_chapter_works_for_last_chapter(dummy_source,
-                                                           monkeypatch):
+def test_generate_multipage_chapter_works_for_last_chapter(
+        dummy_source, monkeypatch):
     """Test _generate_multipage_chapter still works for final chapter."""
     import requests
 
@@ -232,8 +232,8 @@ def test_generate_multipage_chapter_works_for_last_chapter(dummy_source,
     assert len(imgs) == 4
 
 
-def test_generate_multipage_chapter_works_dashed_url(dummy_source,
-                                                     monkeypatch):
+def test_generate_multipage_chapter_works_dashed_url(
+        dummy_source, monkeypatch):
     """Test _generate_multipage_chapter still works for dashed chapter url."""
     import requests
 
@@ -295,8 +295,8 @@ def test_generate_singlepage_chapter_yields_image_and_extension(dummy_source):
     assert ext == 'png'
 
 
-def test_generate_singlepage_chapter_yields_all_images_in_chapter(dummy_source,
-                                                                  monkeypatch):
+def test_generate_singlepage_chapter_yields_all_images_in_chapter(
+        dummy_source, monkeypatch):
     """Test _generate_singlepage_chapter yeilds image data and extention."""
     import requests
 
@@ -392,24 +392,36 @@ def test_chapter_list_raises_error_for_bad_seriescache(value):
         scr.Scraper.chapter_list(value, source)
 
 
-def test_chapter_list_raises_error_when_index_not_found(dummy_source,
-                                                        filled_cache):
+def test_chapter_list_raises_error_when_index_not_found(
+        dummy_source, filled_cache):
     """Test chapter_list raises ValueError for no index found in source."""
+    del filled_cache._chapter_lists[repr(dummy_source)]
     with pytest.raises(ValueError):
         scr.Scraper.chapter_list(filled_cache, dummy_source)
 
 
-def test_chapter_list_uses_cached_list_if_available(filled_cache):
+def test_chapter_list_sets_cached_list_to_none_when_index_not_found(
+        dummy_source, filled_cache):
+    """Test chapter_list sets cached list to None when no index found."""
+    del filled_cache._chapter_lists[repr(dummy_source)]
+    try:
+        scr.Scraper.chapter_list(filled_cache, dummy_source)
+    except ValueError:
+        assert filled_cache._chapter_lists[repr(dummy_source)] is None
+    else:
+        assert False  # Did not raise appropriate errpr
+
+
+def test_chapter_list_uses_cache_list_if_available(filled_cache, dummy_source):
     """Test chapter_list returns the cached chapter list when available."""
-    from .context import mangasource
-    source = mangasource.MangaSource('source2', 'http://www.another.com', '')
-    chapters = filled_cache._chapter_lists[repr(source)]
-    assert scr.Scraper.chapter_list(filled_cache, source) is chapters
+    chapters = filled_cache._chapter_lists[repr(dummy_source)]
+    assert scr.Scraper.chapter_list(filled_cache, dummy_source) is chapters
 
 
 def test_chapter_list_builds_list_if_cache_outdated(filled_cache, monkeypatch):
     """Test chapter_list creates a chapter list when outdated."""
     import requests
+    from .context import mangasource
 
     req = requests_patch(text='''<table>
         <a href="/test-series/5">Chapter link 5</a>
@@ -417,10 +429,8 @@ def test_chapter_list_builds_list_if_cache_outdated(filled_cache, monkeypatch):
     </table>''')
     monkeypatch.setattr(requests, 'get', req)
 
-    from .context import mangasource
-    source = mangasource.MangaSource('source2', 'http://www.another.com', '')
+    source = mangasource.MangaSource('old-source', 'http://old.net/', '')
     chapters = filled_cache._chapter_lists[repr(source)]
-    filled_cache._update_interval = 5000
 
     new_chapters = scr.Scraper.chapter_list(filled_cache, source)
     assert new_chapters is not chapters
@@ -438,8 +448,8 @@ def test_chapter_list_builds_list_if_no_cache_available(
     assert type(new_chapters) is dict
 
 
-def test_chapter_list_returns_empty_dict_for_empty_index(dummy_source,
-                                                         empty_cache):
+def test_chapter_list_returns_empty_dict_for_empty_index(
+        dummy_source, empty_cache):
     """Test chapter_list gets empty dict for index with no chapters."""
     from datetime import datetime
     now = datetime.utcnow().timestamp()
@@ -489,8 +499,8 @@ def test_chapter_list_adds_chapter_list_to_cache_missing_chapters(
     assert empty_cache.get_chapter_list(dummy_source) is new_chapters
 
 
-def test_chapter_list_updates_chapter_list_for_old_cache(filled_cache,
-                                                         monkeypatch):
+def test_chapter_list_updates_chapter_list_for_old_cache(
+        filled_cache, monkeypatch):
     """Test chapter_list updates chapter list for an outdated cache."""
     import requests
 
@@ -508,29 +518,100 @@ def test_chapter_list_updates_chapter_list_for_old_cache(filled_cache,
 
 
 @pytest.mark.parametrize('value', [500, [], 2.1, {}])
-def test_chapter_pages_raises_error_for_non_string_url(value):
-    """Test chapter_pages raises a TypeError for bad url."""
+def test_chapter_pages_raises_error_for_non_string_chapter(value):
+    """Test chapter_pages raises a TypeError for bad chapter."""
+    from .context import mangasource
+    from .context import seriescache
+    source = mangasource.MangaSource('test', 'www.test.com', '_')
+    cache = seriescache.SeriesCache('title')
+    with pytest.raises(TypeError):
+        scr.Scraper.chapter_pages(value, cache, source)
+
+
+@pytest.mark.parametrize('value', [500, [], 2.1, {}, 'title'])
+def test_chapter_pages_raises_error_for_bad_seriescache(value):
+    """Test chapter_pages raises a TypeError for bad cache."""
     from .context import mangasource
     source = mangasource.MangaSource('test', 'www.test.com', '_')
     with pytest.raises(TypeError):
-        scr.Scraper.chapter_pages(value, source)
+        scr.Scraper.chapter_pages('http://t.com/', value, source)
 
 
 @pytest.mark.parametrize('value', [500, [], 2.1, {}, 'www.test.com'])
 def test_chapter_pages_raises_error_for_bad_mangasource(value):
     """Test chapter_pages raises a TypeError for bad source."""
+    from .context import seriescache
+    cache = seriescache.SeriesCache('title')
     with pytest.raises(TypeError):
-        scr.Scraper.chapter_pages('http://t.com/', value)
+        scr.Scraper.chapter_pages('http://t.com/', cache, value)
 
 
-def test_chapter_pages_raises_error_for_empty_url(dummy_source):
-    """Test chapter_pages raises ValueError for empty url."""
+def test_chapter_pages_raises_error_for_empty_chap(empty_cache, dummy_source):
+    """Test chapter_pages raises ValueError for empty chapter number."""
     with pytest.raises(ValueError):
-        scr.Scraper.chapter_pages('', dummy_source)
+        scr.Scraper.chapter_pages('', empty_cache, dummy_source)
 
 
-def test_chapter_pages_yields_all_images_in_multipage_chapter(dummy_source,
-                                                              monkeypatch):
+def test_chapter_pages_raises_error_for_chapter_not_in_chapter_list(
+        empty_cache, dummy_source, monkeypatch):
+    """Test chapter_pages raises a KeyError for chapter not in chapter list."""
+    import requests
+
+    req = requests_patch(text='<table><a href="/10">Chapter 10</a></table>')
+    monkeypatch.setattr(requests, 'get', req)
+
+    with pytest.raises(KeyError):
+        scr.Scraper.chapter_pages('1', empty_cache, dummy_source)
+
+
+def test_chapter_pages_uses_cached_chapter_url_when_available(
+        filled_cache, dummy_source, monkeypatch):
+    """Test chapter_pages uses cached chapter URL from chapter list cache."""
+    import requests
+
+    req = requests_patch(text='<table><a href="/10">Chapter 10</a></table>')
+    monkeypatch.setattr(requests, 'get', req)
+
+    chapters = filled_cache.get_chapter_list(dummy_source)
+
+    assert '10' not in chapters and '1' in chapters
+
+    pages = scr.Scraper.chapter_pages('1', filled_cache, dummy_source)
+
+    assert pages is not None
+    with pytest.raises(KeyError):
+        scr.Scraper.chapter_pages('10', filled_cache, dummy_source)
+
+
+def test_chapter_pages_gets_new_chapter_url_when_not_available(
+        empty_cache, dummy_source, monkeypatch):
+    """Test chapter_pages retrieves new chapter list when not available."""
+    import requests
+
+    req = requests_patch(text='<table><a href="/10">Chapter 10</a></table>')
+    monkeypatch.setattr(requests, 'get', req)
+
+    pages = scr.Scraper.chapter_pages('10', empty_cache, dummy_source)
+    assert pages is not None
+
+
+def test_chapter_pages_updates_chapter_list_cache_when_not_available(
+        empty_cache, dummy_source, monkeypatch):
+    """Test chapter_pages retrieves new chapter list when not available."""
+    import requests
+
+    req = requests_patch(text='<table><a href="/10">Chapter 10</a></table>')
+    monkeypatch.setattr(requests, 'get', req)
+
+    assert empty_cache.get_chapter_list(dummy_source) is None
+
+    scr.Scraper.chapter_pages('10', empty_cache, dummy_source)
+
+    assert '10' in empty_cache.get_chapter_list(dummy_source)
+
+
+def test_chapter_pages_yields_all_images_in_multipage_chapter(
+        filled_cache, dummy_source, monkeypatch):
     """Test chapter_pages yeilds all images in multipage source."""
     import requests
 
@@ -538,7 +619,8 @@ def test_chapter_pages_yields_all_images_in_multipage_chapter(dummy_source,
         n = 2
         while True:
             pg = n // 2
-            yield f'''<a href="/{pg // ch_len + 2}/page/{pg % ch_len + 1}">
+            yield f'''
+            <a href="/test_series/{pg // ch_len + 1}/page/{pg % ch_len + 1}">
             <img src="https://file.co/img.png">
             </a>'''
             n += 1
@@ -552,14 +634,14 @@ def test_chapter_pages_yields_all_images_in_multipage_chapter(dummy_source,
     req = requests_patch(text=page_txt(4), content=content())
     monkeypatch.setattr(requests, 'get', req)
 
-    pages = scr.Scraper.chapter_pages('http://t.com/2/page/1', dummy_source)
+    pages = scr.Scraper.chapter_pages('1', filled_cache, dummy_source)
     imgs = [pg for pg in pages]
     assert len(imgs) == 4
     assert imgs[0] != imgs[1] != imgs[2] != imgs[3]
 
 
-def test_chapter_pages_yields_all_images_in_singlepage_chapter(dummy_source,
-                                                               monkeypatch):
+def test_chapter_pages_yields_all_images_in_singlepage_chapter(
+        filled_cache, dummy_source, monkeypatch):
     """Test chapter_pages yeilds all images in singlepage source."""
     import requests
     dummy_source.is_multipage = False
@@ -580,7 +662,7 @@ def test_chapter_pages_yields_all_images_in_singlepage_chapter(dummy_source,
     req = requests_patch(text=page_txt, content=content())
     monkeypatch.setattr(requests, 'get', req)
 
-    pages = scr.Scraper.chapter_pages('http://t.com/1', dummy_source)
+    pages = scr.Scraper.chapter_pages('1', filled_cache, dummy_source)
     imgs = [pg for pg in pages]
     assert len(imgs) == 4
     assert imgs[0] != imgs[1] != imgs[2] != imgs[3]

--- a/tests/test_seriescache.py
+++ b/tests/test_seriescache.py
@@ -78,8 +78,8 @@ def test_contains_true_if_an_item_is_in_the_cache(filled_cache, dummy_source):
     assert (dummy_source in filled_cache) is True
 
 
-def test_contains_false_if_an_item_is_not_in_the_cache(empty_cache,
-                                                       dummy_source):
+def test_contains_false_if_an_item_is_not_in_the_cache(
+        empty_cache, dummy_source):
     """Test that 'in' works with the series cache."""
     assert (dummy_source in empty_cache) is False
 
@@ -90,8 +90,8 @@ def test_has_outdated_cache_raises_error_for_bad_source(empty_cache):
         empty_cache.has_outdated_cache('http://t.co/')
 
 
-def test_has_outdated_cache_true_for_source_not_in_cache(empty_cache,
-                                                         dummy_source):
+def test_has_outdated_cache_true_for_source_not_in_cache(
+        empty_cache, dummy_source):
     """Test has_outdated_cache returns True for source not in cache."""
     assert empty_cache.has_outdated_cache(dummy_source) is True
 
@@ -131,8 +131,8 @@ def test_update_index_raises_error_for_non_string_index_url(value):
         empty_cache().update_index(dummy_source(), value)
 
 
-def test_update_index_adds_new_source_to_cache_if_not_in_cache(empty_cache,
-                                                               dummy_source):
+def test_update_index_adds_new_source_to_cache_if_not_in_cache(
+        empty_cache, dummy_source):
     """Test that update_index adds a new source if not in cache."""
     assert len(empty_cache) == 0
     empty_cache.update_index(dummy_source)
@@ -140,8 +140,8 @@ def test_update_index_adds_new_source_to_cache_if_not_in_cache(empty_cache,
     assert dummy_source in empty_cache
 
 
-def test_update_index_does_not_add_source_if_already_in_cache(filled_cache,
-                                                              dummy_source):
+def test_update_index_does_not_add_source_if_already_in_cache(
+        filled_cache, dummy_source):
     """Test that update_index does not add duplicate of source."""
     assert len(filled_cache) == 3
     assert dummy_source in filled_cache
@@ -150,24 +150,24 @@ def test_update_index_does_not_add_source_if_already_in_cache(filled_cache,
     assert dummy_source in filled_cache
 
 
-def test_update_index_updates_cached_index_for_a_source_in_cache(filled_cache,
-                                                                 dummy_source):
+def test_update_index_updates_cached_index_for_a_source_in_cache(
+        filled_cache, dummy_source):
     """Test that update_index updates the cache of a source."""
     old_index = filled_cache._index_pages[repr(dummy_source)]
     filled_cache.update_index(dummy_source)
     assert old_index != filled_cache._index_pages[repr(dummy_source)]
 
 
-def test_update_index_updates_update_time_for_a_source_in_cache(filled_cache,
-                                                                dummy_source):
+def test_update_index_updates_update_time_for_a_source_in_cache(
+        filled_cache, dummy_source):
     """Test that update_index updates the cache of a source."""
     old_timestamp = filled_cache._last_updated[repr(dummy_source)]
     filled_cache.update_index(dummy_source)
     assert old_timestamp < filled_cache._last_updated[repr(dummy_source)]
 
 
-def test_update_index_uses_root_url_if_no_custom_url_given(filled_cache,
-                                                           dummy_source):
+def test_update_index_uses_root_url_if_no_custom_url_given(
+        filled_cache, dummy_source):
     """Test that update_index uses source root url if no index_url given."""
     filled_cache.update_index(dummy_source)
     index_page = filled_cache._index_pages[repr(dummy_source)]
@@ -182,8 +182,8 @@ def test_update_index_adds_custom_url_if_given(empty_cache, dummy_source):
     assert empty_cache._custom_urls[repr(dummy_source)] == 'http://t.co/testS'
 
 
-def test_update_index_uses_given_custom_url_for_new_source(empty_cache,
-                                                           dummy_source):
+def test_update_index_uses_given_custom_url_for_new_source(
+        empty_cache, dummy_source):
     """Test that update_index uses index_url for index page if given."""
     empty_cache.update_index(dummy_source, 'http://t.co/testS')
     index_page = empty_cache._index_pages[repr(dummy_source)]
@@ -191,8 +191,8 @@ def test_update_index_uses_given_custom_url_for_new_source(empty_cache,
     assert 'http://t.co/testS' in index_page
 
 
-def test_update_index_uses_given_custom_url_for_dup_source(filled_cache,
-                                                           dummy_source):
+def test_update_index_uses_given_custom_url_for_dup_source(
+        filled_cache, dummy_source):
     """Test that update_index uses index_url for index page if given."""
     filled_cache.update_index(dummy_source, 'http://t.co/testS')
     index_page = filled_cache._index_pages[repr(dummy_source)]
@@ -236,17 +236,16 @@ def test_get_index_raises_error_for_non_string_index_url(value):
         empty_cache().get_index(dummy_source(), value)
 
 
-def test_get_index_for_source_not_in_cache_adds_to_cache(empty_cache,
-                                                         dummy_source):
+def test_get_index_for_source_not_in_cache_adds_to_cache(
+        empty_cache, dummy_source):
     """Test that get_index for source not in cache adds it."""
     assert dummy_source not in empty_cache
     empty_cache.get_index(dummy_source)
     assert dummy_source in empty_cache
 
 
-def test_get_index_for_source_not_in_cache_returns_new_index(empty_cache,
-                                                             dummy_source,
-                                                             monkeypatch):
+def test_get_index_for_source_not_in_cache_returns_new_index(
+        empty_cache, dummy_source, monkeypatch):
     """Test that get_index for source not in cache gets its index page."""
     import requests
     index = '<p>chap</p>'
@@ -255,8 +254,8 @@ def test_get_index_for_source_not_in_cache_returns_new_index(empty_cache,
     assert result == index
 
 
-def test_get_index_recent_source_returns_cached_index(filled_cache,
-                                                      dummy_source):
+def test_get_index_recent_source_returns_cached_index(
+        filled_cache, dummy_source):
     """Test that get_index for recent source returns cached index."""
     index = filled_cache._index_pages[repr(dummy_source)]
     result = filled_cache.get_index(dummy_source)
@@ -315,8 +314,8 @@ def test_set_chapter_list_raises_error_for_bad_source(empty_cache):
         empty_cache.set_chapter_list('http://t.co/', {})
 
 
-def test_set_chapter_list_raises_error_for_source_not_in_cache(empty_cache,
-                                                               dummy_source):
+def test_set_chapter_list_raises_error_for_source_not_in_cache(
+        empty_cache, dummy_source):
     """Test set_chapter_list raises a ValueError for source not in cache."""
     with pytest.raises(ValueError):
         empty_cache.set_chapter_list(dummy_source, {})
@@ -372,15 +371,24 @@ def test_set_chapter_list_raises_error_for_improper_or_partial_chap_url(value):
         cache.set_chapter_list(source, {'5': value})
 
 
-def test_set_chapter_list_adds_empty_chapter_list_for_source(filled_cache,
-                                                             dummy_source):
+def test_set_chapter_list_adds_source_to_chapter_list_cache(filled_cache):
+    """Test set_chapter_list adds the source to chap cache if not present."""
+    from .context import mangasource
+    source = mangasource.MangaSource('source2', 'http://www.another.com', '')
+    assert repr(source) not in filled_cache._chapter_lists
+    filled_cache.set_chapter_list(source, {})
+    assert repr(source) in filled_cache._chapter_lists
+
+
+def test_set_chapter_list_sets_empty_chapter_list_for_source(
+        filled_cache, dummy_source):
     """Test set_chapter_list adds chapter list to cache for source."""
     filled_cache.set_chapter_list(dummy_source, {})
     assert filled_cache._chapter_lists[repr(dummy_source)] == {}
 
 
-def test_set_chapter_list_adds_filled_chapter_list_for_source(filled_cache,
-                                                              dummy_source):
+def test_set_chapter_list_sets_filled_chapter_list_for_source(
+        filled_cache, dummy_source):
     """Test set_chapter_list adds chapter list to cache for source."""
     chaps = {
         '5': 'http://foo.bar/chap/5',
@@ -390,17 +398,24 @@ def test_set_chapter_list_adds_filled_chapter_list_for_source(filled_cache,
     assert filled_cache._chapter_lists[repr(dummy_source)] == chaps
 
 
-def test_set_chapter_list_resets_chapter_list_for_source(filled_cache,
-                                                         dummy_source):
+def test_set_chapter_list_resets_chapter_list_for_source(
+        filled_cache, dummy_source):
     """Test set_chapter_list adds chapter list to cache for source."""
-    filled_cache.set_chapter_list(dummy_source, {})
-    assert filled_cache._chapter_lists[repr(dummy_source)] == {}
     chaps = {
         '5': 'http://foo.bar/chap/5',
         '5.3': 'http://foo.bar/chap/5.3'
     }
     filled_cache.set_chapter_list(dummy_source, chaps)
     assert filled_cache._chapter_lists[repr(dummy_source)] == chaps
+    filled_cache.set_chapter_list(dummy_source, {})
+    assert filled_cache._chapter_lists[repr(dummy_source)] == {}
+
+
+def test_set_chapter_list_can_set_chapter_list_to_none(
+        filled_cache, dummy_source):
+    """Test set_chapter_list can set the chapter list for a source to None."""
+    filled_cache.set_chapter_list(dummy_source, None)
+    assert filled_cache._chapter_lists[repr(dummy_source)] is None
 
 
 def test_get_chapter_list_raises_error_for_bad_source(empty_cache):
@@ -409,12 +424,11 @@ def test_get_chapter_list_raises_error_for_bad_source(empty_cache):
         empty_cache.get_chapter_list('http://t.co/')
 
 
-def test_get_chapter_list_returns_stored_list_for_recent_source(filled_cache):
+def test_get_chapter_list_returns_stored_list_for_recent_source(
+        filled_cache, dummy_source):
     """Test get_chapter_list returns cached chapter list for recent source."""
-    from .context import mangasource
-    source = mangasource.MangaSource('source2', 'http://www.another.com', '')
-    chapters = filled_cache._chapter_lists[repr(source)]
-    assert filled_cache.get_chapter_list(source) == chapters
+    chapters = filled_cache._chapter_lists[repr(dummy_source)]
+    assert filled_cache.get_chapter_list(dummy_source) == chapters
 
 
 def test_get_chapter_list_returns_none_for_old_source(filled_cache):
@@ -426,14 +440,15 @@ def test_get_chapter_list_returns_none_for_old_source(filled_cache):
     assert filled_cache.get_chapter_list(source) is None
 
 
-def test_get_chapter_list_returns_none_for_source_not_in_cache(filled_cache):
+def test_get_chapter_list_returns_none_for_source_not_in_cache(empty_cache):
     """Test get_chapter_list returns None for source not in the cache."""
     from .context import mangasource
-    source = mangasource.MangaSource('new!', 'http://hot.co/', '')
-    assert filled_cache.get_chapter_list(source) is None
+    source = mangasource.MangaSource('new one', 'http://new.net', '+')
+    assert empty_cache.get_chapter_list(source) is None
 
 
-def test_get_chapter_list_returns_none_for_source_without_chaps(filled_cache,
-                                                                dummy_source):
+def test_get_chapter_list_returns_none_for_source_without_chaps(filled_cache):
     """Test get_chapter_list returns None for source. without cached chaps."""
-    assert filled_cache.get_chapter_list(dummy_source) is None
+    from .context import mangasource
+    source = mangasource.MangaSource('source2', 'http://www.another.com', '')
+    assert filled_cache.get_chapter_list(source) is None

--- a/tests/test_seriescache.py
+++ b/tests/test_seriescache.py
@@ -18,13 +18,34 @@ def test_constructor_raises_error_for_empty_string_title():
         sc.SeriesCache('')
 
 
+@pytest.mark.parametrize('value', ['500', [], 2.1, {}])
+def test_constructor_raises_error_for_non_int_interval(value):
+    """Test that constructor for SeriesCache takes only int update interval."""
+    with pytest.raises(TypeError):
+        sc.SeriesCache('title', update_interval=value)
+
+
+def test_constructor_raises_error_for_negative_interval():
+    """Test constructor for SeriesCache does not take an negative interval."""
+    with pytest.raises(ValueError):
+        sc.SeriesCache('title', update_interval=-5)
+
+
 def test_constructor_sets_atrributes_and_empty_cache():
     """Test that constructor for SeriesCache initializes empty cache."""
     cache = sc.SeriesCache('testing')
     assert cache.title == 'testing'
+    assert cache._update_interval == 21600
     assert cache._index_pages == {}
     assert cache._custom_urls == {}
+    assert cache._chapter_lists == {}
     assert cache._last_updated == {}
+
+
+def test_constructor_sets_update_interval_to_interval_when_given():
+    """Test that constructor for SeriesCache initializes empty cache."""
+    cache = sc.SeriesCache('testing', update_interval=500)
+    assert cache._update_interval == 500
 
 
 def test_repr_displays_title_and_cache_size_for_empty_cache(empty_cache):
@@ -61,6 +82,39 @@ def test_contains_false_if_an_item_is_not_in_the_cache(empty_cache,
                                                        dummy_source):
     """Test that 'in' works with the series cache."""
     assert (dummy_source in empty_cache) is False
+
+
+def test_has_outdated_cache_raises_error_for_bad_source(empty_cache):
+    """Test has_outdated_cache raises TypeError for non MangaSource source."""
+    with pytest.raises(TypeError):
+        empty_cache.has_outdated_cache('http://t.co/')
+
+
+def test_has_outdated_cache_true_for_source_not_in_cache(empty_cache,
+                                                         dummy_source):
+    """Test has_outdated_cache returns True for source not in cache."""
+    assert empty_cache.has_outdated_cache(dummy_source) is True
+
+
+def test_has_outdated_cache_true_for_old_source(filled_cache):
+    """Test has_outdated_cache returns True for source past update interval."""
+    from .context import mangasource
+    source = mangasource.MangaSource('old-source', 'http://old.net/', '')
+    assert source in filled_cache
+    assert filled_cache.has_outdated_cache(source) is True
+
+
+def test_has_outdated_cache_true_past_custom_update_interval(filled_cache):
+    """Test has_outdated_cache for recent outside interval treats as old."""
+    from .context import mangasource
+    source = mangasource.MangaSource('source2', 'http://www.another.com', '')
+    filled_cache._update_interval = 5000
+    assert filled_cache.has_outdated_cache(source) is True
+
+
+def test_has_outdated_cache_false_for_new_source(filled_cache, dummy_source):
+    """Test has_outdated_cache returns True for source past update interval."""
+    assert filled_cache.has_outdated_cache(dummy_source) is False
 
 
 def test_update_index_raises_error_for_bad_source(empty_cache):
@@ -182,21 +236,6 @@ def test_get_index_raises_error_for_non_string_index_url(value):
         empty_cache().get_index(dummy_source(), value)
 
 
-@pytest.mark.parametrize('value', ['500', [], 2.1, {}])
-def test_get_index_raises_error_for_non_integer_update_interval(value):
-    """Test that get_index raises a TypeError for non integer interval."""
-    from .conftest import empty_cache, dummy_source
-    with pytest.raises(TypeError):
-        empty_cache().get_index(dummy_source(), update_interval=value)
-
-
-def test_get_index_raises_error_for_negative_update_interval(empty_cache,
-                                                             dummy_source):
-    """Test that get_index raises a ValueError for negative interval."""
-    with pytest.raises(ValueError):
-        empty_cache.get_index(dummy_source, update_interval=-5)
-
-
 def test_get_index_for_source_not_in_cache_adds_to_cache(empty_cache,
                                                          dummy_source):
     """Test that get_index for source not in cache adds it."""
@@ -242,15 +281,6 @@ def test_get_index_recent_gets_new_index_for_new_custom_url(filled_cache):
     assert result != old_index
 
 
-def test_get_index_recent_given_update_interval_treats_as_old(filled_cache):
-    """Test that get_index for recent outside interval treats as old source."""
-    from .context import mangasource
-    source = mangasource.MangaSource('source2', 'http://www.another.com', '')
-    old_index = filled_cache._index_pages[repr(source)]
-    result = filled_cache.get_index(source, update_interval=5000)
-    assert result != old_index
-
-
 def test_get_index_old_source_updates_cached_index(filled_cache):
     """Test that get_index for old source updates cached index."""
     from .context import mangasource
@@ -277,3 +307,133 @@ def test_get_index_old_source_updates_url_when_given(filled_cache):
     assert filled_cache._custom_urls[repr(source)] != 'http://o.co/testseries'
     filled_cache.get_index(source, 'http://o.co/testseries')
     assert filled_cache._custom_urls[repr(source)] == 'http://o.co/testseries'
+
+
+def test_set_chapter_list_raises_error_for_bad_source(empty_cache):
+    """Test set_chapter_list raises a TypeError for non MangaSource source."""
+    with pytest.raises(TypeError):
+        empty_cache.set_chapter_list('http://t.co/', {})
+
+
+def test_set_chapter_list_raises_error_for_source_not_in_cache(empty_cache,
+                                                               dummy_source):
+    """Test set_chapter_list raises a ValueError for source not in cache."""
+    with pytest.raises(ValueError):
+        empty_cache.set_chapter_list(dummy_source, {})
+
+
+@pytest.mark.parametrize('value', [500, [], 2.1, '500'])
+def test_set_chapter_list_raises_error_for_non_dict_chapter_list(value):
+    """Test that set_chapter_list raises a TypeError for non dict chap list."""
+    from .conftest import filled_cache, dummy_source
+    source = dummy_source()
+    cache = filled_cache(source)
+    with pytest.raises(TypeError):
+        cache.set_chapter_list(source, value)
+
+
+@pytest.mark.parametrize('value', [500, 2.1, ('55', '56')])
+def test_set_chapter_list_raises_error_for_non_string_chap_nums(value):
+    """Test set_chapter_list raises a ValueError for malformed chap list."""
+    from .conftest import filled_cache, dummy_source
+    source = dummy_source()
+    cache = filled_cache(source)
+    with pytest.raises(ValueError):
+        cache.set_chapter_list(source, {value: 'http://t.co'})
+
+
+@pytest.mark.parametrize('value', ['chap', 'ch.50', 'chapter 4.6'])
+def test_set_chapter_list_raises_error_for_non_number_chap_nums(value):
+    """Test set_chapter_list raises a ValueError for malformed chap list."""
+    from .conftest import filled_cache, dummy_source
+    source = dummy_source()
+    cache = filled_cache(source)
+    with pytest.raises(ValueError):
+        cache.set_chapter_list(source, {value: 'http://t.co'})
+
+
+@pytest.mark.parametrize('value', [500, 2.1, ('55', '56'), [], {}])
+def test_set_chapter_list_raises_error_for_non_string_chap_urls(value):
+    """Test set_chapter_list raises a ValueError for malformed chap list."""
+    from .conftest import filled_cache, dummy_source
+    source = dummy_source()
+    cache = filled_cache(source)
+    with pytest.raises(ValueError):
+        cache.set_chapter_list(source, {'5': value})
+
+
+@pytest.mark.parametrize('value', ['www.goo.co', '/chap/10', '//foo.bar', '5'])
+def test_set_chapter_list_raises_error_for_improper_or_partial_chap_url(value):
+    """Test set_chapter_list raises a ValueError for malformed chap list."""
+    from .conftest import filled_cache, dummy_source
+    source = dummy_source()
+    cache = filled_cache(source)
+    with pytest.raises(ValueError):
+        cache.set_chapter_list(source, {'5': value})
+
+
+def test_set_chapter_list_adds_empty_chapter_list_for_source(filled_cache,
+                                                             dummy_source):
+    """Test set_chapter_list adds chapter list to cache for source."""
+    filled_cache.set_chapter_list(dummy_source, {})
+    assert filled_cache._chapter_lists[repr(dummy_source)] == {}
+
+
+def test_set_chapter_list_adds_filled_chapter_list_for_source(filled_cache,
+                                                              dummy_source):
+    """Test set_chapter_list adds chapter list to cache for source."""
+    chaps = {
+        '5': 'http://foo.bar/chap/5',
+        '5.3': 'http://foo.bar/chap/5.3'
+    }
+    filled_cache.set_chapter_list(dummy_source, chaps)
+    assert filled_cache._chapter_lists[repr(dummy_source)] == chaps
+
+
+def test_set_chapter_list_resets_chapter_list_for_source(filled_cache,
+                                                         dummy_source):
+    """Test set_chapter_list adds chapter list to cache for source."""
+    filled_cache.set_chapter_list(dummy_source, {})
+    assert filled_cache._chapter_lists[repr(dummy_source)] == {}
+    chaps = {
+        '5': 'http://foo.bar/chap/5',
+        '5.3': 'http://foo.bar/chap/5.3'
+    }
+    filled_cache.set_chapter_list(dummy_source, chaps)
+    assert filled_cache._chapter_lists[repr(dummy_source)] == chaps
+
+
+def test_get_chapter_list_raises_error_for_bad_source(empty_cache):
+    """Test get_chapter_list raises a TypeError for non MangaSource source."""
+    with pytest.raises(TypeError):
+        empty_cache.get_chapter_list('http://t.co/')
+
+
+def test_get_chapter_list_returns_stored_list_for_recent_source(filled_cache):
+    """Test get_chapter_list returns cached chapter list for recent source."""
+    from .context import mangasource
+    source = mangasource.MangaSource('source2', 'http://www.another.com', '')
+    chapters = filled_cache._chapter_lists[repr(source)]
+    assert filled_cache.get_chapter_list(source) == chapters
+
+
+def test_get_chapter_list_returns_none_for_old_source(filled_cache):
+    """Test get_chapter_list returns None for old source."""
+    from .context import mangasource
+    source = mangasource.MangaSource('old-source', 'http://old.net/', '')
+    chapters = filled_cache._chapter_lists[repr(source)]
+    assert chapters is not None
+    assert filled_cache.get_chapter_list(source) is None
+
+
+def test_get_chapter_list_returns_none_for_source_not_in_cache(filled_cache):
+    """Test get_chapter_list returns None for source not in the cache."""
+    from .context import mangasource
+    source = mangasource.MangaSource('new!', 'http://hot.co/', '')
+    assert filled_cache.get_chapter_list(source) is None
+
+
+def test_get_chapter_list_returns_none_for_source_without_chaps(filled_cache,
+                                                                dummy_source):
+    """Test get_chapter_list returns None for source. without cached chaps."""
+    assert filled_cache.get_chapter_list(dummy_source) is None


### PR DESCRIPTION
Added caching for the list of available chapters for a series in the SeriesCache class.

List of chapters organized by source and stored in dictionaries where the key is the chapter number as a string and the value is the URL for the first or only page of the chapter.

Also refactored the scraper public methods to make them have a more consistent interface. Both take a SeriesCache and a MangaSource instead of a URL string for the first page of a chapter.